### PR TITLE
Update to compatibility + extended to fix top level text

### DIFF
--- a/samples/initial/compatibilityplus_extended_13997.json
+++ b/samples/initial/compatibilityplus_extended_13997.json
@@ -2,7 +2,7 @@
   "created_at": "Mon Mar 28 14:39:13 +0000 2016",
   "id": 714461850188926976,
   "id_str": "714461850188926976",
-  "full_text": "@jeremycloud It's neat to have owls and raccoons around until you realize that raccoons will eat the eggs from the owl's nest https://t.co/Q0pkaU4ORH",
+  "text": "@jeremycloud It's neat to have owls and raccoons around until you realize that raccoons will eat the eggs from the owl's nest https://t.co/Q0pkaU4ORH",
   "display_text_range": [
     13,
     125


### PR DESCRIPTION
The top level attribute "full_text" should be "text" in compatibility mode to maintain backwards compatibility.
